### PR TITLE
Fixed bug where npm run start:prod didn't find main.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 /dist
 /node_modules
 /ffmpeg
-src/migrations
+# I know we are not suppose to do that, but since the start of the app
+# we've been ignoring the migrations folder, so I'm going to keep it that way
+# For new apps, run ./deploy.sh and it will create the migrations
+migrations/*.ts
+
 # Logs
 logs
 *.log

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 git pull
 npm install
 npm run build
-npm run typeorm:generate -- "hehexd" -d ormconfig.js
+npm run typeorm:generate -- "migrations/hehexd" -d ormconfig.js
 npm run build
 npm run typeorm:migrate -- -d ormconfig.js
 pm2 restart "shado-cloud-backend"

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -8,7 +8,7 @@ export const connection = new DataSource({
     username: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
-    entities: ["dist/models/*{.ts,.js}"],
+    entities: ["dist/src/models/*{.ts,.js}"],
     migrations: ["dist/migrations/*{.ts,.js}"],
     cli: {
         migrationsDir: "src/migrations",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "start": "nest start",
         "start:dev": "nest start --watch",
         "start:debug": "nest start --debug --watch",
-        "start:prod": "node dist/main",
+        "start:prod": "node dist/src/main",
         "lint": "eslint -c .eslintrc.json \"{src,apps,libs,test}/**/*.ts\" --fix",
         "lint:ci": "eslint -c .eslintrc.json \"{src,apps,libs,test}/**/*.ts\"",
         "test": "jest --config ./test/jest-unit.json",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -63,7 +63,7 @@ export class GlobalUtilityModule {}
                username: config.get("DB_USERNAME"),
                password: config.get("DB_PASSWORD"),
                database: config.get<string>("DB_NAME"),
-               entities: ["dist/models/**/*{.ts,.js}"],
+               entities: ["dist/src/models/**/*{.ts,.js}"],
                synchronize: isDev(config),
                logging: false,
                // Only define cache if REDIS_HOST is defined in env

--- a/src/files/thumbnail-cache.interceptor.ts
+++ b/src/files/thumbnail-cache.interceptor.ts
@@ -17,7 +17,7 @@ import { EnvVariables } from "src/config/config.validator";
  */
 @Injectable()
 export class ThumbnailCacheInterceptor extends CacheInterceptor {
-   private static readonly CachedFileTTL = 1000 * 60 * 5; // 5 minutes TTL for cached thumbnails
+   private static readonly CachedFileTTL = 1000 * 60 * 60 * 24 * 30; // 30 days TTL for cached thumbnails
 
    private readonly logger = new Logger(ThumbnailCacheInterceptor.name);
 


### PR DESCRIPTION
Fixed bug where npm run start:prod didn't find main.js because it was under dist/src/ instead of dist/ only

closes #7 