### PR TITLE
Removed @nestjs/cache and cache-manager and simplified caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.0.1",
             "license": "UNLICENSED",
             "dependencies": {
-                "@nestjs/cache-manager": "^2.3.0",
                 "@nestjs/common": "^10.4.13",
                 "@nestjs/config": "^3.3.0",
                 "@nestjs/core": "^10.4.13",
@@ -23,8 +22,6 @@
                 "@types/sharp": "^0.29.5",
                 "archiver": "^5.3.2",
                 "argon2": "^0.28.7",
-                "cache-manager": "^5.7.6",
-                "cache-manager-ioredis": "^2.1.0",
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.14.1",
                 "cookie-parser": "^1.4.7",
@@ -2037,17 +2034,6 @@
             "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
             "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
             "license": "MIT"
-        },
-        "node_modules/@nestjs/cache-manager": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-2.3.0.tgz",
-            "integrity": "sha512-pxeBp9w/s99HaW2+pezM1P3fLiWmUEnTUoUMLa9UYViCtjj0E0A19W/vaT5JFACCzFIeNrwH4/16jkpAhQ25Vw==",
-            "peerDependencies": {
-                "@nestjs/common": "^9.0.0 || ^10.0.0",
-                "@nestjs/core": "^9.0.0 || ^10.0.0",
-                "cache-manager": "<=5",
-                "rxjs": "^7.0.0"
-            }
         },
         "node_modules/@nestjs/cli": {
             "version": "10.4.8",
@@ -4762,82 +4748,6 @@
             "license": "ISC",
             "optional": true
         },
-        "node_modules/cache-manager": {
-            "version": "5.7.6",
-            "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-5.7.6.tgz",
-            "integrity": "sha512-wBxnBHjDxF1RXpHCBD6HGvKER003Ts7IIm0CHpggliHzN1RZditb7rXoduE1rplc2DEFYKxhLKgFuchXMJje9w==",
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^5.0.1",
-                "lodash.clonedeep": "^4.5.0",
-                "lru-cache": "^10.2.2",
-                "promise-coalesce": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/cache-manager-ioredis": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cache-manager-ioredis/-/cache-manager-ioredis-2.1.0.tgz",
-            "integrity": "sha512-TCxbp9ceuFveTKWuNaCX8QjoC41rAlHen4s63u9Yd+iXlw3efYmimc/u935PKPxSdhkXpnMes4mxtK3/yb0L4g==",
-            "license": "MIT",
-            "dependencies": {
-                "ioredis": "^4.14.1"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/cache-manager-ioredis/node_modules/denque": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-            "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/cache-manager-ioredis/node_modules/ioredis": {
-            "version": "4.28.5",
-            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-            "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
-            "license": "MIT",
-            "dependencies": {
-                "cluster-key-slot": "^1.1.0",
-                "debug": "^4.3.1",
-                "denque": "^1.1.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isarguments": "^3.1.0",
-                "p-map": "^2.1.0",
-                "redis-commands": "1.7.0",
-                "redis-errors": "^1.2.0",
-                "redis-parser": "^3.0.0",
-                "standard-as-callback": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/ioredis"
-            }
-        },
-        "node_modules/cache-manager-ioredis/node_modules/p-map": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/cache-manager/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-        },
         "node_modules/call-bind": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -6947,11 +6857,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/eventemitter3": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
         },
         "node_modules/events": {
             "version": "3.3.0",
@@ -10325,11 +10230,6 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "license": "MIT"
         },
-        "node_modules/lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-        },
         "node_modules/lodash.defaults": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -12060,14 +11960,6 @@
             "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/promise-coalesce": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/promise-coalesce/-/promise-coalesce-1.1.2.tgz",
-            "integrity": "sha512-zLaJ9b8hnC564fnJH6NFSOGZYYdzrAJn2JUUIwzoQb32fG2QAakpDNM+CZo1km6keXkRXRM+hml1BFAPVnPkxg==",
-            "engines": {
-                "node": ">=16"
-            }
         },
         "node_modules/promise-inflight": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "typeorm:migrate": "typeorm migration:run"
     },
     "dependencies": {
-        "@nestjs/cache-manager": "^2.3.0",
         "@nestjs/common": "^10.4.13",
         "@nestjs/config": "^3.3.0",
         "@nestjs/core": "^10.4.13",
@@ -38,8 +37,6 @@
         "@types/sharp": "^0.29.5",
         "archiver": "^5.3.2",
         "argon2": "^0.28.7",
-        "cache-manager": "^5.7.6",
-        "cache-manager-ioredis": "^2.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "cookie-parser": "^1.4.7",

--- a/src/admin/app-metrics.service.ts
+++ b/src/admin/app-metrics.service.ts
@@ -1,22 +1,13 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import Redis from "ioredis";
-import { EnvVariables } from "src/config/config.validator";
+import type Redis from "ioredis";
+import { REDIS_CACHE } from "src/util";
 
 @Injectable()
 export class AppMetricsService {
-   private readonly redis: Redis;
-
    // Max length of string values to dump
-   private readonly maxLength = 200; // You can change this to whatever suits your needs
+   private readonly maxLength = 150;
 
-   constructor(@Inject() readonly config: ConfigService<EnvVariables>) {
-      this.redis = new Redis({
-         host: config.get<string>("REDIS_HOST"),
-         port: Number(config.get<string>("REDIS_PORT")),
-         password: config.get<string>("REDIS_PASSWORD"),
-      });
-   }
+   constructor(@Inject(REDIS_CACHE) private readonly redis: Redis) {}
 
    public async redisInfo(section: string): Promise<string> {
       return await this.redis.info(section);

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,10 +7,8 @@ import { type Request } from "express";
 import { type CookiePayload } from "./auth/authApiTypes";
 import { ConfigService } from "@nestjs/config";
 import { EnvVariables } from "./config/config.validator";
-import { type Cache } from "cache-manager";
-import type Redis from "ioredis";
 
-export type RedisCache = Cache & { store: { getClient: () => Redis } };
+export const REDIS_CACHE = "REDIS_CACHE" as const;
 
 /**
  * @example Use this function as decorator on top of controller functions

--- a/test/auth/auth.service.test.ts
+++ b/test/auth/auth.service.test.ts
@@ -3,9 +3,9 @@ import { AuthService } from "src/auth/auth.service";
 import { User } from "src/models/user";
 import { type Repository } from "typeorm";
 import { getRepositoryToken } from "@nestjs/typeorm";
-import { Logger } from "@nestjs/common";
 import argon2 from "argon2";
-import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { REDIS_CACHE } from "src/util";
+import { LoggerToDb } from "src/logging";
 
 jest.mock("argon2");
 
@@ -26,10 +26,16 @@ describe("AuthService", () => {
                },
             },
             {
-               provide: CACHE_MANAGER,
+               provide: REDIS_CACHE,
                useValue: {
                   get: jest.fn().mockReturnValue(null),
                   set: jest.fn(),
+               },
+            },
+            {
+               provide: LoggerToDb,
+               useValue: {
+                  warn: jest.fn(),
                },
             },
          ],


### PR DESCRIPTION
Removed @nestjs/cache and cache-manager and simplified caching because they added an additional layer of complexity and the thumbnail interceptor TTL was not being used correctly